### PR TITLE
Change page language from en to am to use translator correctly

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="am">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
I would like to set the language of the page to be Amharic, not English, so that it translates correctly.

## Before
![image](https://github.com/user-attachments/assets/14a0ed7a-3333-4bb3-b417-eb859929c6da)

## After

Due to a problem with Google Translate, the year 2017 is translated as 217.

![image](https://github.com/user-attachments/assets/cced10c6-f785-4961-b4f2-7a329061e3e8)
